### PR TITLE
fix(nutshell): Remove extra exe

### DIFF
--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -70,7 +70,7 @@ impl Shell for Nushell {
               | parse vars
               | update-env
             }} else {{
-              ^"{exe}" {exe} $command $rest
+              ^"{exe}" $command $rest
             }}
           }}
             


### PR DESCRIPTION
This extra exe causes the exe to try and call itself resulting in the following error: error: unrecognized subcommand '/usr/local/bin/rtx'

  tip: a similar subcommand exists: 'local'
  tip: to pass '/usr/local/bin/rtx' as a value, use 'rtx -- /usr/local/bin/rtx'

Usage: rtx [OPTIONS] <COMMAND>

For more information, try '--help'.